### PR TITLE
Update `parseSerialNumber` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This plugin adds Samsung TV's available in your local network to homebridge.
 
 Just install the plugin in the [config-ui-x](https://github.com/oznu/homebridge-config-ui-x) plugin tab or with `npm i -g homebridge-samsungtv-control@latest`, turn on all your Samsung TV's so they can be discovered and restart homebridge.
 
+The plugin parses the model number of the Samsung TV extract specific info about the model. The plugin currently parses model numbers from 2018 through 2020.
+
 # Customize devices
 
 After you started homebridge you should see the device names with their usn in the homebridge log. To customize a device, add an object with the usn (including `uuid:`) and any option you want to modify to the devices list under the `SamsungTVControl` platform. You could e.g. change the initial name like so:

--- a/src/utils/parseSerialNumber.ts
+++ b/src/utils/parseSerialNumber.ts
@@ -13,25 +13,19 @@ const markets = {
   A: `Asia`,
 } as const
 const years = {
-  Q: [2017, 2018, 2019],
-  RU: 2019,
-  NU: 2018,
-  N: 2018,
-  LS: 2018,
-  MU: 2017,
-  M: 2017,
-  KS: 2016,
-  KU: 2016,
-  K: 2016,
-  JS: 2015,
-  JU: 2015,
-  J: 2015,
-  HU: 2014,
-  H: 2014,
+  T: 2020, // TU: 2020
+  R: 2019, // RU: 2019
+  Q: [2017, 2018, 2019, 2020],
+  N: 2018, // NU: 2018
+  LS: [2015, 2017, 2018, 2019, 2020],
+  // For the LS** model numbers, they all start with "LS" and and with their year code,
+  // so getting a more accurate year could be possible.
+  M: 2017, // MU: 2017
+  K: 2016, // KS, KU: 2016
+  J: 2015, // JS, JU: 2015
+  H: 2014, // HU: 2014
   F: 2013,
-  E: 2012,
-  ES: 2012,
-  EH: 2012,
+  E: 2012, // ES, EH: 2012
   D: 2011,
   C: 2010,
   B: 2009,
@@ -52,6 +46,7 @@ export interface SamsungTVModel {
 /**
  * Parses Samsung TV Serial numbers into more specific infos
  * @see https://www.samsung.com/de/support/tv-audio-video/was-bedeutet-der-modellcode-meines-fernsehers/
+ * @see https://www.samsung.com/us/support/answer/ANS00087664/
  * @param sn SerialNumber
  */
 export default (sn: string): SamsungTVModel | null => {

--- a/src/utils/tests/parseSerialNumber.test.ts
+++ b/src/utils/tests/parseSerialNumber.test.ts
@@ -27,6 +27,6 @@ test(`parseSerialNumber`, () => {
   expect(model4!.size).toEqual(55)
   expect(model4!.year).toEqual(2020)
 
-  const model4 = parseSerialNumber(`laskdnalskndla`)
-  expect(model4).toBeFalsy()
+  const model5 = parseSerialNumber(`laskdnalskndla`)
+  expect(model5).toBeFalsy()
 })

--- a/src/utils/tests/parseSerialNumber.test.ts
+++ b/src/utils/tests/parseSerialNumber.test.ts
@@ -20,6 +20,13 @@ test(`parseSerialNumber`, () => {
   expect(model3!.size).toEqual(42)
   expect(model3!.year).toEqual(2015)
 
+  const model4 = parseSerialNumber(`UN55TU7000FXZA`)
+  expect(model4).not.toBeFalsy()
+  expect(model4!.market).toEqual(`Northamerica`)
+  expect(model4!.technology).toEqual(`LED`)
+  expect(model4!.size).toEqual(55)
+  expect(model4!.year).toEqual(2020)
+
   const model4 = parseSerialNumber(`laskdnalskndla`)
   expect(model4).toBeFalsy()
 })


### PR DESCRIPTION
`parseSerialNumber` is outdated (see #40). I updated the years to include 2020. I also added a note in the README to reflect the fact that model numbers through 2020 can be parsed. If a newer model is produced by Samsung, `parseSerialNumber` will have to be updated again.

Reference from Samsung: https://www.samsung.com/us/support/answer/ANS00087664/

Fixes #70, #48, #40.