### PR TITLE
Tweaked manual configuration option (e. g. for "Series C" model names)

### DIFF
--- a/src/utils/detectDevices.ts
+++ b/src/utils/detectDevices.ts
@@ -64,7 +64,7 @@ const checkDeviceDetails = async (
   // ) {
   //   return null
   // }
-  if (typeof modelName !== `string` || !modelName.length) {
+  if (typeof modelName !== `string` || !modelName.length || modelName === "Samsung DTV DMR") {
     // Check if the modelName was configured manually
     const configuredDevice = deviceCustomizations.find((d) => d.usn === usn)
     if (configuredDevice && configuredDevice.modelName) {


### PR DESCRIPTION
Older devices such as my 2010 C7700 may report a generic modelName 'Samsung DTV DMR'. The code change allows to use the manual configuration option (via usn) of the plugin. This will solve #56. 

Configuration:
`
{
    "platform": "SamsungTVControl",
    "devices": [
        {
            "usn": "uuid:nnnn",
            "name": "Samsung TV",
            **"modelName": "UE46C7700WSXZG"**,
        }
    ]
}
`

Debug Output:
`
deviceDescription: {
  deviceType: 'urn:schemas-upnp-org:device:MediaRenderer:1',
  friendlyName: 'TV-46C7700',
  manufacturer: 'Samsung Electronics',
  manufacturerURL: 'http://www.samsung.com',
  modelName: '**Samsung DTV DMR**',
  modelNumber: 1,
  modelDescription: 'Samsung DTV DMR',
  UDN: 'uuid:nnnn',
  icons: [ ....
`